### PR TITLE
Bugfixes

### DIFF
--- a/src/Helpers/MofParser.ps1
+++ b/src/Helpers/MofParser.ps1
@@ -346,7 +346,7 @@ function ConvertFrom-MofFile {
 			# Load actual resrouce definition.
 			$key = "$($r.Resource.Name)_$($module['ModuleName'])_$($module['ModuleVersion'])"
 			$actual = $script:ParsingStatus.ActualResources[$key]
-			if ($null -eq $actual) { $actual = Get-DscResource $r.Resource.Name -Module $module -ErrorAction SilentlyContinue }
+			if ($null -eq $actual) { $actual = Get-DscResource $r.Resource.Name -Module $module -ErrorAction SilentlyContinue -Verbose:$false }
 
 			# If actual resource found, look for used properties, looking for bool or int that were converted
 			# but are actually strings.

--- a/src/Public/Invoke-DscConfiguration.ps1
+++ b/src/Public/Invoke-DscConfiguration.ps1
@@ -31,7 +31,7 @@ function Invoke-DscConfiguration {
 		if ($PSVersionTable.PSVersion.Major -le 5) { $PowershellCore = $false }
 
 		$ModernDSC = $false
-		foreach ($m in (Get-Module PSDesiredStateConfiguration -ListAvailable)) {
+		foreach ($m in (Get-Module PSDesiredStateConfiguration -ListAvailable -Verbose:$false)) {
 			if ($m.Version.Major -gt 1) {
 				$ModernDSC = $true
 				break
@@ -41,7 +41,7 @@ function Invoke-DscConfiguration {
 		# Make sure Invoke-DscResource is enabled in Powershell Core, since
 		# it's an experimental feature and it's disabled by default.
 		if ($PowershellCore) {
-			if (-not (Get-ExperimentalFeature PSDesiredStateConfiguration.InvokeDscResource | Select-Object -ExpandProperty Enabled)) {
+			if (-not (Get-ExperimentalFeature PSDesiredStateConfiguration.InvokeDscResource -Verbose:$false | Select-Object -ExpandProperty Enabled)) {
 				throw 'Experimental feature PSDesiredStateConfiguration.InvokeDscResource must be enabled to use this command. Use "Enable-ExperimentalFeature PSDesiredStateConfiguration.InvokeDscResource" and restart the Powershell session.'
 			}
 		}
@@ -49,7 +49,7 @@ function Invoke-DscConfiguration {
 		# If running in a session that uses DSC 1.1, warn if the LCM is configured
 		# in a way that might interfere.
 		if (!$ModernDSC) {
-			$lcm = Get-DscLocalConfigurationManager
+			$lcm = Get-DscLocalConfigurationManager -Verbose:$false
 
 			if ($lcm.RefreshMode -ine 'Disabled') {
 				Write-Warning 'It is strongly suggested that the LCM is disabled when using the PSDSCAgent.'
@@ -111,7 +111,7 @@ function Invoke-DscConfiguration {
 					}
 
 					# Modern DSC supports verbose.
-					if ($ModernDSC -and ($PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent) -or $VerbosePreference -eq 'Continue') {
+					if ($ModernDSC -and (($PSCmdlet.MyInvocation.BoundParameters['Verbose'].IsPresent) -or $VerbosePreference -eq 'Continue')) {
 						$params['Verbose'] = $true
 					}
 

--- a/src/Public/Invoke-DscConfiguration.ps1
+++ b/src/Public/Invoke-DscConfiguration.ps1
@@ -53,12 +53,10 @@ function Invoke-DscConfiguration {
 
 			if ($lcm.RefreshMode -ine 'Disabled') {
 				Write-Warning 'It is strongly suggested that the LCM is disabled when using the PSDSCAgent.'
-				#TODO: make sure that Get-DscResource works when the LCM is disabled
 			}
 
 			if ($lcm.RebootNodeIfNeeded) {
 				Write-Warning 'It is strongly suggested that the LCM not control the reboot, so the PSDSCAgent can handle it.'
-				#TODO: make sure that this setting actually has impact if the LCM is in disabled
 			}
 		}
 	}
@@ -115,9 +113,12 @@ function Invoke-DscConfiguration {
 						$params['Verbose'] = $true
 					}
 
+					# Prepare module information.
 					$module = @{ ModuleName = $resource.Resource.ModuleName; ModuleVersion = $resource.Resource.ModuleVersion }
+					# If module is default PSDesiredStateConfiguration, make it a string as using a hashmap
+					# can create issues with versions and PsDscRunAsCredential.
 					if ($module['ModuleName'] -eq 'PSDesiredStateConfiguration' -and $module['ModuleVersion'] -eq '1.0') {
-						$module['ModuleVersion'] = '1.1'
+						$module = 'PSDesiredStateConfiguration'
 					}
 
 					# Test the status of the resource.

--- a/src/Public/Invoke-DscConfiguration.ps1
+++ b/src/Public/Invoke-DscConfiguration.ps1
@@ -117,7 +117,7 @@ function Invoke-DscConfiguration {
 					$module = @{ ModuleName = $resource.Resource.ModuleName; ModuleVersion = $resource.Resource.ModuleVersion }
 					# If module is default PSDesiredStateConfiguration, make it a string as using a hashmap
 					# can create issues with versions and PsDscRunAsCredential.
-					if ($module['ModuleName'] -eq 'PSDesiredStateConfiguration' -and $module['ModuleVersion'] -eq '1.0') {
+					if ($module['ModuleName'] -eq 'PSDesiredStateConfiguration') {
 						$module = 'PSDesiredStateConfiguration'
 					}
 


### PR DESCRIPTION
- Corrected bug where parameter Verbose in Invoke-DscResource would be used also in DSC 1.1, resulting in an error during execution
- Reduced amount of useless verbose output in DSC 1.1
- Solved issue where parameter PsDscRunAsCredential would cause an error in DSC 1.1 when using default resources